### PR TITLE
[Docs] Updated links to bach-editor

### DIFF
--- a/LEARNING.md
+++ b/LEARNING.md
@@ -82,3 +82,6 @@
  - https://gist.github.com/noprompt/9086232 (slurp.clj gist)
  - https://github.com/minimal-xyz/minimal-shadow-cljs-esm
  - https://github.com/reagent-project/reagent/blob/master/shadow-cljs.edn
+
+## Documentation
+ - https://michaelcurrin.github.io/docsify-js-tutorial/#/

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -9,4 +9,4 @@
 
 [Getting Started](#getting-started)
 [Examples](/examples)
-[Editor](https://slurmulon.github.io/bach-editor)
+[Editor](https://editor.codebach.tech)

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -9,4 +9,4 @@
 
 [Getting Started](#getting-started)
 [Examples](/examples)
-[GitHub](https://github.com/slurmulon/bach)
+[Editor](https://slurmulon.github.io/bach-editor)

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -207,7 +207,7 @@ Stores all data locally via browser storage, so be careful if you're using a pri
 
 #### App
 
-[:musical_keyboard:](https://slurmulon.github.io/bach-editor) https://slurmulon.github.io/bach-editor
+[:musical_keyboard:](https://editor.codebach.tech) https://editor.codebach.tech
 
 #### Repo
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -193,13 +193,25 @@ $ npm test
 
 `bach` only becomes functional and therefore useful with the help of a `bach` interpreter library and a `bach` engine.
 
-We have provided official libraries in JavaScript to serve both of these purposes.
+We have provided a web editor an low-level libraries in JavaScript to serve both of these purposes.
 
-We have also started planning an open-source `bach` sandbox/editor tool that will provide a standard experience for rapid, instant-feedback authoring of `bach` tracks.
+### `bach-editor`
 
-Until that time you will need to rely on the following tools in order to fully actualize your `bach` tracks.
+#### About
 
-Of course, open-source contributions are fully welcomed and encouraged to the `bach` ecosystem of tools.
+Official web editor/player for `bach`.
+
+Allows you to hear and visualize your tracks, manage track archives and access useful track information.
+
+Stores all data locally via browser storage, so be careful if you're using a private browser and create periodic archives of your tracks.
+
+#### App
+
+[:musical_keyboard:](https://slurmulon.github.io/bach-editor) https://slurmulon.github.io/bach-editor
+
+#### Repo
+
+[![Github Logo](_media/github.svg)](https://github.com/slurmulon/bach-editor) https://github.com/slurmulon/bach-editor
 
 ### `gig`
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,7 @@
 
 All of the examples found here represent the loopable chord and scale progressions of backing/jam tracks.
 
-You can use our open-source **[web editor](https://slurmulon.github.io/bach-editor)** to run any of the examples found here by simply copying and pasting the code into the editor and pressing play.
+You can use our open-source **[web editor](https://editor.codebach.tech)** to run any of the examples found here by simply copying and pasting the code into the editor and pressing play.
 
 This collection will eventually be updated to include examples of full songs that include multiple parts.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,37 +2,31 @@
 
 All of the examples found here represent the loopable chord and scale progressions of backing/jam tracks.
 
+You can use our open-source **[web editor](https://slurmulon.github.io/bach-editor)** to run any of the examples found here by simply copying and pasting the code into the editor and pressing play.
+
 This collection will eventually be updated to include examples of full songs that include multiple parts.
 
 If you have suggestions or want to contribute example tracks yourself, please head to the [Contribute](contribute) page.
-
-> :construction:
->
-> Tooling support is currently limited and none of these example tracks have runnable audio (yet, but will soon).
->
-> We are working on an open-source `bach` editor that will allow you to play all of these examples with their associated audio, generated via the Web Audio API.
->
-> Until then, you will have to use your imagination, or use something like `tone.js` (until we write an official `bach-tone` library, that is).
 
 ## Basic
 
 ```bach
 @Meter = 4|4
-@Tempo = 44
+@Tempo = 128
 
 :B = Chord('Bm')
 :E = Chord('Em')
 :F = Chord('F#m7')
 
 !Play [
-  4 -> {
+  1 -> {
     Scale('B minor')
     :B
   }
-  2 -> :E
-  2 -> :B
-  2 -> :F
-  2 -> :B
+  1/2 -> :E
+  1/2 -> :B
+  1/2 -> :F
+  1/2 -> :B
 ]
 ```
 
@@ -110,7 +104,7 @@ If you have suggestions or want to contribute example tracks yourself, please he
 
 ```bach
 @Meter = 3|4
-@Tempo = 100
+@Tempo = 132
 
 !Play [
   6/4 -> {

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -18,13 +18,33 @@ You can find a collection of useful example tracks in the [Examples](#examples) 
 
 > If you are looking for a more technical and low-level resource on `bach`, head to the [Syntax](/syntax) page instead.
 
-> :warning:
->
-> Because `bach` is a new technology, playback support, such as with audio, is currently only accessible to those with programming expertise (via [`gig`](/dev#gig)).
->
-> If you're a musician with little to no programming experience, we still encourage you to continue reading this guide, but just be aware that you are currently unable to run any example tracks or tracks that you author.
->
-> We are working on an open-source web editor that will allow you to author and play `bach` tracks, but in the meantime we hope you enjoy what you read!
+## Editor
+
+An open-source [`bach-editor`](https://github.com/slurmulon/bach-editor) is publically available over the web at **https://slurmulon.github.io/bach-editor**.
+
+You can, and should, use this tool to run example `bach` tracks that you encounter in the guide.
+
+The editor allows you to both hear and visualize the `bach` track, manage collections and access useful information about your track.
+
+It also provides some basic usability settings to enhance and customize your experience.
+
+### Usage
+
+To run an example track in the editor, simply copy the code (or hover over it and click the "Copy to clipboard" button), then replace the contents of the code in your editor, directly under the "Code" tab.
+
+Then simply click the blue play button in the bottom right. You should hear piano keys being played as your screen screen scrolls with the music (optional).
+
+If you run into any problems with the editor, please be sure to open up an [issue on GitHub](https://github.com/slurmulon/bach-editor/issues) with a detailed description of your problem and reproduction steps.
+
+### Limits
+
+It's a new tool and currently only supports playback via piano (limited to the second octave for now, due to complexities acquiring a full open-source collection of sampled instruments keys).
+
+The tool may eventually support multiple instruments, but long-term it will remain as minimal as possible to reduce overall complexity and maintenance overhead.
+
+It also stores all data locally using browser storage due to hosting costs, so be sure to use the archive feature to create backups of your track collections.
+
+> :warning: If you're using a private browser and close the window or end the session, you will lose your tracks unless you already created an archive!
 
 ## Components
 
@@ -50,21 +70,21 @@ The following track represents the chord progression of a soul song.
 
 ```bach
 @Meter = 4|4
-@Tempo = 44
+@Tempo = 175
 
 :B = Chord('Bm')
 :E = Chord('Em')
 :F = Chord('F#m7')
 
 !Play [
-  4 -> {
+  2 -> {
     Scale('B minor')
     :B
   }
-  2 -> :E
-  2 -> :B
-  2 -> :F
-  2 -> :B
+  1 -> :E
+  1 -> :B
+  1 -> :F
+  1 -> :B
 ]
 ```
 
@@ -74,15 +94,15 @@ Putting special characters aside, we can see that several musical elements are c
  - **Tempo**: `44` beats per minute
  - **Chord**: `Bm`, `Em` and `F#m7`
  - **Scale**: `B minor`
- - **Durations**: `4`, `2`
+ - **Durations**: `2`, `1`
 
 Once this track is processed and loaded into an app, it will be interpreted like so:
 
-1. The scale `B minor` and the chord `:B`, or `Bm`, will be played for `4` whole notes, then
-1. The chord `:E`, or `Em`, will be played for `2` whole notes, then
-1. The chord `:B`, or `Bm`, will be played for `2` whole notes, then
-1. The chord `:F`, or `F#m7`, will be played for `2` whole notes, then
-1. The chord `:B`, or `Bm`, will be played for `2` whole notes, then
+1. The scale `B minor` and the chord `:B`, or `Bm`, will be played for `2` whole notes, then
+1. The chord `:E`, or `Em`, will be played for `1` whole note, then
+1. The chord `:B`, or `Bm`, will be played for `1` whole note, then
+1. The chord `:F`, or `F#m7`, will be played for `1` whole notes, then
+1. The chord `:B`, or `Bm`, will be played for `1` whole notes, then
 1. Repeat as desired
 
 > We will go into what "processed" means in the [Authoring](#authoring) section.
@@ -317,10 +337,10 @@ Sets are defined the same way as lists with one key difference: they use curly b
 { Scale('B minor'), Chord('Bm') }
 ```
 
-In the example from the [Tracks](#tracks) section, both a scale and chord will played on the first beat for 4 whole notes.
+In the example from the [Tracks](#tracks) section, both a scale and chord will played on the first beat for 2 whole notes.
 
 ```bach
-4 -> {
+2 -> {
   Scale('B minor')
   Chord('Bm')
 }
@@ -413,7 +433,7 @@ The value of a duration can be an integer, a fraction, or a mathematical express
 1/8  = Eighth note
 1/16 = Sixteenth note
 
-1/512 = Minimum duration
+1/128 = Minimum duration
 1024  = Maximum duration
 
 2 + (1/2) = Two and a half whole notes
@@ -668,13 +688,6 @@ Only one `!Play` element is allowed and expected per track, and anything that is
 
 ## Authoring
 
-> :warning:
->
-> If you are a musician with minimal programming experience, you should consider this is the end of the guide for now.
->
-> We are actively creating a `bach` editor so that anyone can author and playback `bach` tracks in the browser.
->
-> For the time being, track playback is only accessible to [developers](dev).
 
 Now that you are familiar with the fundamentals, we can begin putting `bach` to practical use by authoring some tracks.
 
@@ -684,27 +697,13 @@ It's much better to start off with a block of marble and carve out a sculpture t
 
 That is why we provide an open-source collection of [examples tracks](#examples) for you to copy and modify to your liking.
 
-But before we can even begin to make use of these examples (let alone change or build upon them), we must become familiar with the tools available to us.
-
 ### Tooling
 
-Today, all of the tooling for `bach` is programmatic. In other words, `bach` can easily be used by programmers, but not so easily by musicians since essential high-level tools for `bach` are still being developed.
+You have a `bach` track, so how do we associate and synchronize it with real-time audio (in other words, how do we run it)?
 
-For instsance, eventually we will provide an open-source `bach` web editor that will allow you to author and play `bach` tracks entirely in the browser.
+If you've followed the guide linearly then you're already familiar with our open-source **[web editor](https://slurmulon.github.io/bach-editor)** and have used it to run example tracks.
 
-Until that point, all of `bach`'s tooling is highly technical and built for software engineers.
-
-### Audio
-
-> :warning: Audio playback can currently only be achieved programmatically via [`gig`](dev#gig).
-
-You have a `bach` track written, so how do we associate and synchronize it with audio?
-
-The first thing to note is that, in order to keep `bach` simple and focused, `bach` doesn't explicitly concern itself with audio data.
-
-By taking this approach it allows `bach` to rhythmically align with music produced by a human or to generate music on a computer.
-
-On a practical level, this means it's up to your editor or application to associate audio data with your `bach` tracks.
+If you haven't used the editor yet, we certainly advise that you check it out and run some example tracks. This allows you to see `bach` in action and how everything ultimately comes together.
 
 ## Examples
 
@@ -713,7 +712,6 @@ You can find a collection of open-source example tracks in the [Examples](exampl
 ## Limitations
 
  - New project that is still taking shape and finding its place in the world (so, there's not much tooling, yet :sob:)
- - No working sandbox/editor for `bach` (in the works :construction:)
  - No interpretation or application of music theory, such as the notes that make up a scale or code (this is the responsibility of [`bach-js`](/dev#bach-js))
  - No reserved aliases for common semantic durations (e.g. `:bar`, `1/2 * :bar`, etc)
  - No official support yet for clef

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -20,7 +20,7 @@ You can find a collection of useful example tracks in the [Examples](#examples) 
 
 ## Editor
 
-An open-source [`bach-editor`](https://github.com/slurmulon/bach-editor) is publically available over the web at **https://slurmulon.github.io/bach-editor**.
+An open-source [`bach-editor`](https://github.com/slurmulon/bach-editor) is publically available over the web at **https://editor.codebach.tech**.
 
 You can, and should, use this tool to run example `bach` tracks that you encounter in the guide.
 
@@ -701,7 +701,7 @@ That is why we provide an open-source collection of [examples tracks](#examples)
 
 You have a `bach` track, so how do we associate and synchronize it with real-time audio (in other words, how do we run it)?
 
-If you've followed the guide linearly then you're already familiar with our open-source **[web editor](https://slurmulon.github.io/bach-editor)** and have used it to run example tracks.
+If you've followed the guide linearly then you're already familiar with our open-source **[web editor](https://editor.codebach.tech)** and have used it to run example tracks.
 
 If you haven't used the editor yet, we certainly advise that you check it out and run some example tracks. This allows you to see `bach` in action and how everything ultimately comes together.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,8 @@
       loadSidebar: true,
       auto2top: true,
       coverpage: true,
-      themeColor: 'salmon',
+      // themeColor: 'salmon',
+      themeColor: '#FAA372',
       nameLink: '#/',
       // logo: '_media/logo-round.gif'
     }

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -29,26 +29,20 @@ An [Extended Backus-Naur Form (EBNF)](https://en.wikipedia.org/wiki/Extended_Bac
 ## Preview
 
 ```bach
-@Meter = 4|4
-@Tempo = 110
-
-:Bb = Scale('Bb mixolydian')
-:Eb = Scale('Eb mixolydian')
-:Db = Scale('Bb dorian')
-:Gb = Scale('Bb aeolian')
-:Eb = Scale('Bb dorian')
+@Tempo = 159
+@Meter = 6|8
 
 !Play [
-  4 -> :Bb
-  4 -> :Eb
-  5 -> :Bb
-  1 -> :Db
-  1 -> :Gb
-  1 -> :Eb
-  4 -> :Bb
+  1 * 6/8 -> {
+    Scale('D minor')
+    Chord('Dmin')
+  }
+  1 * 6/8 -> Chord('Dmin/F')
+  1 * 6/8 -> Chord('E7b9')
+  1 * 6/8 -> Chord('Bb7')
+  2 * 6/8 -> Chord('A7')
 ]
 ```
-
 
 ## Documentation
 

--- a/docs/theme.css
+++ b/docs/theme.css
@@ -1,8 +1,11 @@
 :root {
   --base-font-size: 14px;
-  --theme-color: salmon;
+  /* --theme-color: salmon; */
+  /* --theme-color: #FAA372; */
+  --theme-color: #FA9F6D;
   --cover-heading-font-size: 64px;
-  --cover-blockquote-color: salmon;
+  /* --cover-blockquote-color: salmon; */
+  --cover-blockquote-color: var(--theme-color);
 }
 
 .logo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,18 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -281,6 +293,13 @@
         "randomfill": "^1.0.3"
       }
     },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -310,10 +329,32 @@
         }
       }
     },
+    "docsify": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/docsify/-/docsify-4.12.0.tgz",
+      "integrity": "sha512-oLr48dLeJ8sTVQfL8HLFqd2sPPG8DNAOvYAXXJQr/+/K9uC2KDhoeu+GGj5U2uFGR5czF3oLvqNBxhEElg1wGw==",
+      "dev": true,
+      "requires": {
+        "dompurify": "^2.2.6",
+        "marked": "^1.2.9",
+        "medium-zoom": "^1.0.6",
+        "opencollective-postinstall": "^2.0.2",
+        "prismjs": "^1.23.0",
+        "strip-indent": "^3.0.0",
+        "tinydate": "^1.3.0",
+        "tweezer.js": "^1.4.0"
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true
+    },
+    "dompurify": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
+      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ==",
       "dev": true
     },
     "elliptic": {
@@ -353,6 +394,16 @@
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "google-closure-library": {
@@ -449,6 +500,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "marked": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
+      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -459,6 +516,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "medium-zoom": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.6.tgz",
+      "integrity": "sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg==",
+      "dev": true
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -477,6 +540,12 @@
           "dev": true
         }
       }
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -527,6 +596,12 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true
+    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -569,6 +644,15 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "prismjs": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
       }
     },
     "process": {
@@ -708,6 +792,13 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
+    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -807,6 +898,15 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -815,6 +915,19 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
+      "optional": true
+    },
+    "tinydate": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinydate/-/tinydate-1.3.0.tgz",
+      "integrity": "sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==",
+      "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -826,6 +939,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "tweezer.js": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/tweezer.js/-/tweezer.js-1.5.0.tgz",
+      "integrity": "sha512-aSiJz7rGWNAQq7hjMK9ZYDuEawXupcCWgl3woQQSoDP2Oh8O4srWb/uO1PzzHIsrPEOqrjJ2sUb9FERfzuBabQ==",
       "dev": true
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,17 @@
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {
+    "docsify": "^4.12.0",
     "shadow-cljs": "^2.11.15"
   },
   "scripts": {
     "dev": "npx shadow-cljs compile lib && npx shadow-cljs watch lib",
     "build": "npx shadow-cljs release lib",
+    "build:esm": "npx shadow-cljs release esm",
     "repl": "npx shadow-cljs node-repl lib",
     "cljs-repl": "npx shadow-cljs cljs-repl lib",
     "clj-repl": "npx shadow-cljs clj-repl lib",
+    "docs": "npx docsify serve docs",
     "test": "npx shadow-cljs compile test"
   },
   "repository": {


### PR DESCRIPTION
**Changes**
 - :link: Updated host of main docsite to https://codebach.tech
 - :link: Updated docsite links to hosted `bach-editor` (now https://editor.codebach.tech)
 - :scroll: Replaced all warnings and messages around non-existent `bach-editor` (now exists!)
 - :lipstick: Lightened up primary theme color of docs (same is already being used in `bach-editor`)
 - :tv: Speed up some example tracks that played too slowly in `bach-editor` (the playback speed is correct/accurate, the configured tempo is just not user-friendly).
 - :vhs: Added NPM scripts (`docs` and `build:esm`)

**Future**
 - :sparkles: Add Prism editor and stylesheet to doc's example snippets